### PR TITLE
Document Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository notes
+
+## Cursor Cloud specific instructions
+
+- Actual is a Yarn 4/Node monorepo. Standard commands are defined in `package.json`; browser E2E details live in `packages/desktop-client/README.md`.
+- The browser development stack is the primary Cloud path: run `yarn start` from the repo root to start the loot-core browser worker and Vite web app on port 3001. The sync server is a separate service and is not required for local/no-server budget flows.
+- In this Cloud image, `/exec-daemon` can appear before nvm on `PATH`. If `node --version` does not match `.nvmrc` after `nvm use`, prepend the nvm Node bin before running Yarn, for example `export PATH="$HOME/.nvm/versions/node/v18.16.0/bin:$PATH"`.
+- If Chrome shows a blank `localhost:3001` page with `ERR_INSUFFICIENT_RESOURCES` for bundles, open a fresh browser origin at `http://127.0.0.1:3001/`; the Vite server can still be healthy.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

## Summary
- Add Cursor Cloud notes for running the Actual browser dev stack, Node path caveat, and Chrome localhost workaround.

## Validation
- Installed Yarn dependencies with Node 18 and Playwright Chromium.
- Ran lint, typecheck, unit tests, browser build, live dev server, onboarding E2E, and a local-account hello-world flow.

## Walkthrough artifacts
[actual_budget_local_account_flow.mp4](https://cursor.com/agents/bc-85253206-82a0-4839-ab76-c43dcc76c855/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factual_budget_local_account_flow.mp4)
[Actual Budget Cloud Savings account](https://cursor.com/agents/bc-85253206-82a0-4839-ab76-c43dcc76c855/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factual_budget_cloud_savings.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85253206-82a0-4839-ab76-c43dcc76c855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85253206-82a0-4839-ab76-c43dcc76c855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

